### PR TITLE
post-test-changes/challenge-1

### DIFF
--- a/interview/inventory/fixtures/inventory_views_fixtures.json
+++ b/interview/inventory/fixtures/inventory_views_fixtures.json
@@ -1,0 +1,78 @@
+[
+  {
+    "model": "inventory.inventorylanguage",
+    "pk": 1,
+    "fields": {
+        "created_at": "2024-05-30T19:36:17.594Z",
+        "updated_at": "2024-05-30T19:36:17.594Z",
+        "name": "Abkhaz"
+    }
+},
+{
+  "model": "inventory.inventorytype",
+  "pk": 3,
+  "fields": {
+      "created_at": "2024-05-30T19:36:17.713Z",
+      "updated_at": "2024-05-30T19:36:17.713Z",
+      "name": "Version"
+  }
+},
+{
+  "model": "inventory.inventorytag",
+  "pk": 1,
+  "fields": {
+      "created_at": "2024-05-30T19:36:17.701Z",
+      "updated_at": "2024-05-30T19:36:17.701Z",
+      "is_active": true,
+      "name": "Action"
+  }
+},
+{
+    "model": "inventory.inventory",
+    "pk": 1,
+    "fields": {
+        "created_at": "2024-05-01T19:36:17.716Z",
+        "updated_at": "2024-05-30T19:36:17.716Z",
+        "name": "The Matrix",
+        "type": 3,
+        "language": 1,
+        "metadata": {
+            "year": 1999,
+            "actors": [
+                "Keanu Reeves",
+                "Laurence Fishburne",
+                "Carrie-Anne Moss"
+            ],
+            "imdb_rating": 8.7,
+            "rotten_tomatoes_rating": 87
+        },
+        "tags": [
+            1
+        ]
+    }
+},
+{
+    "model": "inventory.inventory",
+    "pk": 5,
+    "fields": {
+        "created_at": "2024-05-5T19:36:17.742Z",
+        "updated_at": "2024-05-30T19:36:17.742Z",
+        "name": "The Lord of the Rings: The Fellowship of the Ring",
+        "type": 3,
+        "language": 1,
+        "metadata": {
+            "year": 2001,
+            "actors": [
+                "Elijah Wood",
+                "Ian McKellen",
+                "Viggo Mortensen"
+            ],
+            "imdb_rating": 8.8,
+            "rotten_toamtoes_rating": 91
+        },
+        "tags": [
+            1
+        ]
+    }
+}
+]

--- a/interview/inventory/models.py
+++ b/interview/inventory/models.py
@@ -4,7 +4,7 @@ from interview.core.behaviors import IsActiveModel, NameModel, TimestampedModel,
 
 
 class InventoryTag(UniqueNameModel, TimestampedModel, IsActiveModel, models.Model):
-        
+      
     def __str__(self) -> str:
         return self.name
 

--- a/interview/inventory/tests.py
+++ b/interview/inventory/tests.py
@@ -1,0 +1,30 @@
+from django.test import TestCase
+from django.utils.http import urlencode
+from interview.inventory.models import Inventory
+
+
+class TestInventoryViews(TestCase):
+
+    def test_inventory_list_view_with_invalid_after_date(self):
+        '''
+        Test that 400 status response is provided when an invalid date string format
+        is used
+        '''
+        after_date_query = urlencode({'after-date': 'invalid-date'})
+        path = f"/inventory/?{after_date_query}"
+        response = self.client.get(path)
+        self.assertEquals(response.status_code, 400)
+
+
+    def test_inventory_list_view_with_valid_after_date(self):
+        '''
+        Test that Inventory list request with an after-date query string returns
+        only inventory created after provided date
+        '''
+        after_date_query = urlencode({'after-date': '2020-10-03T19:00:00+0200'})
+        path = f"/inventory/?{after_date_query}"
+        response = self.client.get(path)
+        '''
+            Left off here, need to parse json response, check that response data matches expected size in inventory
+        '''
+        

--- a/interview/inventory/tests.py
+++ b/interview/inventory/tests.py
@@ -1,30 +1,66 @@
 from django.test import TestCase
 from django.utils.http import urlencode
 from interview.inventory.models import Inventory
-
+from datetime import datetime, timedelta
+from django.utils.dateparse import parse_datetime
+from interview.inventory import views
+from rest_framework.response import Response
 
 class TestInventoryViews(TestCase):
+    fixtures = ['inventory_views_fixtures.json']
+    inventory_objs = Inventory.objects.all().order_by('created_at')
 
-    def test_inventory_list_view_with_invalid_after_date(self):
+    @classmethod
+    def setUpClass(cls):
         '''
-        Test that 400 status response is provided when an invalid date string format
-        is used
+        Clear all Inventory objects before running tests
+        so that only those provided in fixtures are present in database
         '''
-        after_date_query = urlencode({'after-date': 'invalid-date'})
+        all_inventory = Inventory.objects.all()
+        all_inventory.delete()
+        super(TestInventoryViews, cls).setUpClass()
+
+    def request_inventory_after_date(self, after_date: str) -> Response:
+        '''
+        make a request to inventory endpoint with the provided date
+        value as ?after_date= in query string
+        '''
+        after_date_query = urlencode({'after-date': after_date})
         path = f"/inventory/?{after_date_query}"
-        response = self.client.get(path)
+        return self.client.get(path)
+
+    def test_inventory_list_view_with_invalid_after_date(self) -> None:
+        '''
+        Test that 400 status response is provided when an invalid date string 
+        format is used
+        '''
+        response = self.request_inventory_after_date('invalid-date')
+        self.assertIs(response.resolver_match.func.__name__, views.InventoryListCreateView.as_view().__name__)
         self.assertEquals(response.status_code, 400)
 
-
-    def test_inventory_list_view_with_valid_after_date(self):
+    def test_inventory_list_view_with_earliest_after_date(self) -> None:
         '''
         Test that Inventory list request with an after-date query string returns
-        only inventory created after provided date
+        all inventory created after the date provided
         '''
-        after_date_query = urlencode({'after-date': '2020-10-03T19:00:00+0200'})
-        path = f"/inventory/?{after_date_query}"
-        response = self.client.get(path)
-        '''
-            Left off here, need to parse json response, check that response data matches expected size in inventory
-        '''
+        earliest_created_date = self.inventory_objs[0].created_at
+        after_date = earliest_created_date - timedelta(1)
+        response = self.request_inventory_after_date(after_date)
+        self.assertEquals(response.status_code, 200)
+        self.assertIs(response.resolver_match.func.__name__, views.InventoryListCreateView.as_view().__name__)
+        self.assertEquals(len(response.data), len(self.inventory_objs))
         
+        # verify each item in response data was created before the after_date provided
+        for e in response.data:
+            self.assertGreater(self.inventory_objs.get(id=e['id']).created_at, after_date)
+            
+    def test_inventory_list_view_with_latest_after_date(self) -> None:
+        '''
+        Test that inventory list request with an after-date query string beyond
+        any existing records returns no data
+        '''
+        latest_created_date = self.inventory_objs.last().created_at
+        response = self.request_inventory_after_date(latest_created_date)
+        self.assertEquals(response.status_code, 200)
+        self.assertIs(response.resolver_match.func.__name__, views.InventoryListCreateView.as_view().__name__)
+        self.assertEquals(len(response.data), 0)

--- a/interview/inventory/urls.py
+++ b/interview/inventory/urls.py
@@ -1,6 +1,6 @@
 
 from django.urls import path
-from interview.inventory.views import InventoryLanguageListCreateView, InventoryLanguageRetrieveUpdateDestroyView, InventoryListCreateView, InventoryRetrieveUpdateDestroyView, InventoryTagListCreateView, InventoryTagRetrieveUpdateDestroyView, InventoryTypeListCreateView, InventoryTypeRetrieveUpdateDestroyView, InventoryListView
+from interview.inventory.views import InventoryLanguageListCreateView, InventoryLanguageRetrieveUpdateDestroyView, InventoryListCreateView, InventoryRetrieveUpdateDestroyView, InventoryTagListCreateView, InventoryTagRetrieveUpdateDestroyView, InventoryTypeListCreateView, InventoryTypeRetrieveUpdateDestroyView
 from interview.order.views import OrderListCreateView, OrderTagListCreateView
 
 
@@ -12,5 +12,5 @@ urlpatterns = [
     path('languages/', InventoryLanguageListCreateView.as_view(), name='inventory-languages-list'),
     path('tags/', InventoryTagListCreateView.as_view(), name='inventory-tags-list'),
     path('types/', InventoryTypeListCreateView.as_view(), name='inventory-types-list'),
-    path('', InventoryListView, name='inventory-list'),
+    path('', InventoryListCreateView.as_view(), name='inventory-list'),
 ]

--- a/interview/inventory/urls.py
+++ b/interview/inventory/urls.py
@@ -1,6 +1,6 @@
 
 from django.urls import path
-from interview.inventory.views import InventoryLanguageListCreateView, InventoryLanguageRetrieveUpdateDestroyView, InventoryListCreateView, InventoryRetrieveUpdateDestroyView, InventoryTagListCreateView, InventoryTagRetrieveUpdateDestroyView, InventoryTypeListCreateView, InventoryTypeRetrieveUpdateDestroyView
+from interview.inventory.views import InventoryLanguageListCreateView, InventoryLanguageRetrieveUpdateDestroyView, InventoryListCreateView, InventoryRetrieveUpdateDestroyView, InventoryTagListCreateView, InventoryTagRetrieveUpdateDestroyView, InventoryTypeListCreateView, InventoryTypeRetrieveUpdateDestroyView, InventoryListView
 from interview.order.views import OrderListCreateView, OrderTagListCreateView
 
 
@@ -12,5 +12,5 @@ urlpatterns = [
     path('languages/', InventoryLanguageListCreateView.as_view(), name='inventory-languages-list'),
     path('tags/', InventoryTagListCreateView.as_view(), name='inventory-tags-list'),
     path('types/', InventoryTypeListCreateView.as_view(), name='inventory-types-list'),
-    path('', InventoryListCreateView.as_view(), name='inventory-list'),
+    path('', InventoryListView, name='inventory-list'),
 ]

--- a/interview/inventory/views.py
+++ b/interview/inventory/views.py
@@ -29,10 +29,11 @@ class InventoryListCreateView(APIView):
     
     def get(self, request, *args, **kwargs) -> Response:
 
+        # check for after-date query string and filter queryset
         if request.GET.get('after-date'):
             after_date = parse_datetime(request.GET.get('after-date'))
             if not after_date:
-                return Response("Invalid date provided. Please provide a valid datetime string including timezone. eg '2020-10-03T19:00:00+0200' ", status=400)
+                return Response("Invalid date provided. Please provide a valid ISO 8601 string including timezone. ex '2020-10-03T19:00:00+0200' ", status=400)
             self.queryset = self.queryset.filter(created_at__gt=after_date)
     
         serializer = self.serializer_class(self.queryset, many=True)


### PR DESCRIPTION
### Add filtering inventory results by created_at to `inventory-list`

#### Affected APIs:
**Inventory**

#### Affected Paths:
`GET /inventory`

#### Usage:
Include the query string parameter `after-date` with a valid ISO 8601 date/time format date/time value including timezone.  When provided, inventory list results will be filtered to include only inventory objects results which have a created_at field later than the provided date/time. Invalid date/time values will cause a 400 response with an error message.

#### Valid date example 
Request
```
GET /inventory?after-date=2025-10-03T19%3A00%3A00%2B0200
```
Response Status: **200**
```
{[
	{
		"id": 1,
		"name": "The Matrix",
		"type": {
			"id": 3,
			"name": "Version"
		},
		"language": {
			"id": 1,
			"name": "Abkhaz"
		},
		"tags": [
			{
				"id": 1,
				"name": "Action",
				"is_active": true
			}
		],
		"metadata": {
			"year": 1999,
			"actors": [
				"Keanu Reeves",
				"Laurence Fishburne",
				"Carrie-Anne Moss"
			],
			"imdb_rating": 8.7,
			"rotten_tomatoes_rating": 87
		}
	},
 ..]}
```


#### Invalid date request example
```
GET /inventory?after-date=non-iso-string
```
 Response Status: **400**
```
"Invalid date provided. Please provide a valid ISO 8601 string including timezone. ex '2020-10-03T19:00:00+0200' "
```


