### PR TITLE
post-test-changes/challenge-2

### DIFF
--- a/interview/order/fixtures/order_views_fixtures.json
+++ b/interview/order/fixtures/order_views_fixtures.json
@@ -1,0 +1,82 @@
+[
+
+
+{
+    "model": "inventory.inventorylanguage",
+    "pk": 1,
+    "fields": {
+        "created_at": "2024-05-30T19:36:17.594Z",
+        "updated_at": "2024-05-30T19:36:17.594Z",
+        "name": "Abkhaz"
+    }
+},
+{
+  "model": "inventory.inventorytype",
+  "pk": 3,
+  "fields": {
+      "created_at": "2024-05-30T19:36:17.713Z",
+      "updated_at": "2024-05-30T19:36:17.713Z",
+      "name": "Version"
+  }
+},
+{
+  "model": "inventory.inventorytag",
+  "pk": 1,
+  "fields": {
+      "created_at": "2024-05-30T19:36:17.701Z",
+      "updated_at": "2024-05-30T19:36:17.701Z",
+      "is_active": true,
+      "name": "Action"
+  }
+},
+{
+    "model": "order.ordertag",
+    "pk": 1,
+    "fields": {
+        "created_at": "2024-05-30T19:36:17.701Z",
+        "updated_at": "2024-05-30T19:36:17.701Z",
+        "is_active": true,
+        "name": "A Tag"
+    }
+  },
+  
+{
+    "model": "order.order",
+    "pk": 1,
+    "fields": {
+        "created_at": "2024-05-30T19:36:17.811Z",
+        "updated_at": "2024-05-30T19:36:17.811Z",
+        "is_active": false,
+        "inventory": 1,
+        "start_date": "2024-05-30",
+        "embargo_date": "2024-06-29",
+        "tags": [
+            1
+        ]
+    }
+},
+{
+    "model": "inventory.inventory",
+    "pk": 1,
+    "fields": {
+        "created_at": "2024-05-01T19:36:17.716Z",
+        "updated_at": "2024-05-30T19:36:17.716Z",
+        "name": "The Matrix",
+        "type": 3,
+        "language": 1,
+        "metadata": {
+            "year": 1999,
+            "actors": [
+                "Keanu Reeves",
+                "Laurence Fishburne",
+                "Carrie-Anne Moss"
+            ],
+            "imdb_rating": 8.7,
+            "rotten_tomatoes_rating": 87
+        },
+        "tags": [
+            1
+        ]
+    }
+}
+]

--- a/interview/order/tests.py
+++ b/interview/order/tests.py
@@ -1,0 +1,41 @@
+from django.test import TestCase
+from interview.order.models import Order
+
+
+class TestOrderViews(TestCase):
+    fixtures = ['order_views_fixtures.json']
+    order_objs = Order.objects.all()
+    
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Clear all Order objects before running tests
+        so that only those provided in fixtures are present in database
+        '''
+        all_orders = Order.objects.all()
+        all_orders.delete()
+        super(TestOrderViews, cls).setUpClass()
+        
+    def test_update_order_active_status_true(self) -> None:
+        '''
+        Test setting active status of an order to True
+        '''
+        order = self.order_objs.first()
+        self.assertFalse(order.is_active)
+        response = self.client.patch(f'/orders/{order.id}/active', {"is_active": True}, content_type="application/json")
+        self.assertEquals(response.status_code, 200)
+        order.refresh_from_db()
+        self.assertTrue(order.is_active)
+
+    def test_update_order_active_status_false(self) -> None:
+        '''
+        Test setting active status of an order to False
+        '''
+        order = self.order_objs.first()
+        order.is_active = True
+        order.save()
+        self.assertTrue(order.is_active)
+        response = self.client.patch(f'/orders/{order.id}/active', {"is_active": False}, content_type="application/json")
+        self.assertEquals(response.status_code, 200)
+        order.refresh_from_db()
+        self.assertFalse(order.is_active)

--- a/interview/order/urls.py
+++ b/interview/order/urls.py
@@ -1,10 +1,10 @@
 
 from django.urls import path
-from interview.order.views import OrderListCreateView, OrderTagListCreateView
+from interview.order.views import OrderListCreateView, OrderTagListCreateView, DeactivateOrderView
 
 
 urlpatterns = [
     path('tags/', OrderTagListCreateView.as_view(), name='order-detail'),
+    path('<int:id>/active', DeactivateOrderView.as_view(), name='activate-order'),
     path('', OrderListCreateView.as_view(), name='order-list'),
-
 ]

--- a/interview/order/views.py
+++ b/interview/order/views.py
@@ -23,6 +23,15 @@ class DeactivateOrderView(APIView):
     serializer_class = OrderSerializer
 
     def patch(self, request: Request, *args, **kwargs) -> Response:
+        '''
+        Update an order to set is_active to the value provided in request
+
+        expected request body:
+        {
+            "is_active": true|false
+        }
+        '''
+
         order = self.get_queryset(id=kwargs['id'])
         update_data = {'is_active': request.data['is_active']}
         serializer = self.serializer_class(order, data=update_data, partial=True)

--- a/interview/order/views.py
+++ b/interview/order/views.py
@@ -1,5 +1,8 @@
 from django.shortcuts import render
 from rest_framework import generics
+from rest_framework.response import Response
+from rest_framework.request import Request
+from rest_framework.views import APIView
 
 from interview.order.models import Order, OrderTag
 from interview.order.serializers import OrderSerializer, OrderTagSerializer
@@ -13,3 +16,22 @@ class OrderListCreateView(generics.ListCreateAPIView):
 class OrderTagListCreateView(generics.ListCreateAPIView):
     queryset = OrderTag.objects.all()
     serializer_class = OrderTagSerializer
+
+
+class DeactivateOrderView(APIView):
+    queryset = Order.objects.all()
+    serializer_class = OrderSerializer
+
+    def patch(self, request: Request, *args, **kwargs) -> Response:
+        order = self.get_queryset(id=kwargs['id'])
+        serializer = self.serializer_class(order, data=request.data, partial=True)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+        
+        serializer.save()
+
+        return Response(serializer.data, status=200)
+    
+    def get_queryset(self, **kwargs):
+        return self.queryset.get(**kwargs)
+        

--- a/interview/order/views.py
+++ b/interview/order/views.py
@@ -24,7 +24,8 @@ class DeactivateOrderView(APIView):
 
     def patch(self, request: Request, *args, **kwargs) -> Response:
         order = self.get_queryset(id=kwargs['id'])
-        serializer = self.serializer_class(order, data=request.data, partial=True)
+        update_data = {'is_active': request.data['is_active']}
+        serializer = self.serializer_class(order, data=update_data, partial=True)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
         


### PR DESCRIPTION
### Add endpoint to update Order `is_active` status *activate-order*

#### Affected APIs:
**Order**

#### New Endpoint:

```
content-type="application/json"
PATCH /order/<int:order_id>/active
``` 
#### Usage:
Patch requests can be made to update the `is_active` for a specific order. Order ID should be included in the path, and the message body should provide:
```
{
    "is_active": true|false
}
```

####  Example 
Request
```
content-type="application/json"
PATCH /order/1/active
{
    "is_active": true
}
```
Response Status: **200**
```
{
	"id": 1,
	"inventory": {...},
	"start_date": "2024-10-30",
	"embargo_date": "2024-06-29",
	"tags": {...},
	"is_active": true
}
```