### PR TITLE
post-test-changes/challenge-3

### DIFF
--- a/interview/order/fixtures/order_views_fixtures.json
+++ b/interview/order/fixtures/order_views_fixtures.json
@@ -1,0 +1,82 @@
+[
+
+
+{
+    "model": "inventory.inventorylanguage",
+    "pk": 1,
+    "fields": {
+        "created_at": "2024-05-30T19:36:17.594Z",
+        "updated_at": "2024-05-30T19:36:17.594Z",
+        "name": "Abkhaz"
+    }
+},
+{
+  "model": "inventory.inventorytype",
+  "pk": 3,
+  "fields": {
+      "created_at": "2024-05-30T19:36:17.713Z",
+      "updated_at": "2024-05-30T19:36:17.713Z",
+      "name": "Version"
+  }
+},
+{
+  "model": "inventory.inventorytag",
+  "pk": 1,
+  "fields": {
+      "created_at": "2024-05-30T19:36:17.701Z",
+      "updated_at": "2024-05-30T19:36:17.701Z",
+      "is_active": true,
+      "name": "Action"
+  }
+},
+{
+    "model": "order.ordertag",
+    "pk": 1,
+    "fields": {
+        "created_at": "2024-05-30T19:36:17.701Z",
+        "updated_at": "2024-05-30T19:36:17.701Z",
+        "is_active": true,
+        "name": "A Tag"
+    }
+  },
+  
+{
+    "model": "order.order",
+    "pk": 1,
+    "fields": {
+        "created_at": "2024-05-30T19:36:17.811Z",
+        "updated_at": "2024-05-30T19:36:17.811Z",
+        "is_active": false,
+        "inventory": 1,
+        "start_date": "2024-05-30",
+        "embargo_date": "2024-06-29",
+        "tags": [
+            1
+        ]
+    }
+},
+{
+    "model": "inventory.inventory",
+    "pk": 1,
+    "fields": {
+        "created_at": "2024-05-01T19:36:17.716Z",
+        "updated_at": "2024-05-30T19:36:17.716Z",
+        "name": "The Matrix",
+        "type": 3,
+        "language": 1,
+        "metadata": {
+            "year": 1999,
+            "actors": [
+                "Keanu Reeves",
+                "Laurence Fishburne",
+                "Carrie-Anne Moss"
+            ],
+            "imdb_rating": 8.7,
+            "rotten_tomatoes_rating": 87
+        },
+        "tags": [
+            1
+        ]
+    }
+}
+]

--- a/interview/order/tests.py
+++ b/interview/order/tests.py
@@ -1,0 +1,43 @@
+from django.test import TestCase
+from datetime import timedelta
+from django.utils.dateparse import parse_date
+from interview.order.models import Order
+
+class TestOrderViews(TestCase):
+    fixtures = ['order_views_fixtures.json']
+    order_objs = Order.objects.all()
+    
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Clear all Order objects before running tests
+        so that only those provided in fixtures are present in database
+        '''
+        all_orders = Order.objects.all()
+        all_orders.delete()
+        super(TestOrderViews, cls).setUpClass()
+        
+    def test_order_within_embargo_dates(self) -> None:
+        '''
+        Test that providing a valid date range returns all orders within that start and
+        embargo date range
+        '''
+        start_date = self.order_objs.first().start_date
+        embargo_date = self.order_objs.first().embargo_date
+        response = self.client.get(f'/orders/?start_date={start_date}&embargo_date={embargo_date}')
+        self.assertEquals(response.status_code, 200)
+        self.assertGreater(len(response.data), 0)
+        for order in response.data:
+            self.assertGreaterEqual(parse_date(order['start_date']), start_date)
+            self.assertLessEqual(parse_date(order['embargo_date']), embargo_date)
+
+    def test_order_within_embargo_dates_no_results(self) -> None:
+        '''
+        Test that when providing a valid date range that no records fall within,
+        an empty result set is provided
+        '''
+        start_date = self.order_objs.first().start_date + timedelta(1)
+        embargo_date = self.order_objs.first().embargo_date - timedelta(1)
+        response = self.client.get(f'/orders/?start_date={start_date}&embargo_date={embargo_date}')
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(len(response.data), 0)

--- a/interview/order/urls.py
+++ b/interview/order/urls.py
@@ -2,7 +2,6 @@
 from django.urls import path
 from interview.order.views import OrderListCreateView, OrderTagListCreateView
 
-
 urlpatterns = [
     path('tags/', OrderTagListCreateView.as_view(), name='order-detail'),
     path('', OrderListCreateView.as_view(), name='order-list'),

--- a/interview/order/views.py
+++ b/interview/order/views.py
@@ -1,13 +1,28 @@
 from django.shortcuts import render
 from rest_framework import generics
+from django.utils.dateparse import parse_datetime
+from rest_framework.response import Response
+from rest_framework.request import Request
 
 from interview.order.models import Order, OrderTag
 from interview.order.serializers import OrderSerializer, OrderTagSerializer
 
 # Create your views here.
 class OrderListCreateView(generics.ListCreateAPIView):
-    queryset = Order.objects.all()
     serializer_class = OrderSerializer
+
+    def get(self, request: Request, *args, **kwargs) -> Response:
+        serializer = self.serializer_class(self.get_queryset(), many=True)
+        return Response(serializer.data, status=200)
+    
+    def get_queryset(self):
+        queryset = Order.objects.all()
+        start_date = parse_datetime(self.request.query_params.get('start_date'))
+        embargo_date = parse_datetime(self.request.query_params.get('embargo_date'))
+        if start_date and embargo_date:
+            queryset = queryset.filter(start_date__gte=start_date, embargo_date__lte=embargo_date)
+
+        return queryset
     
 
 class OrderTagListCreateView(generics.ListCreateAPIView):

--- a/interview/order/views.py
+++ b/interview/order/views.py
@@ -17,9 +17,15 @@ class OrderListCreateView(generics.ListCreateAPIView):
     
     def get_queryset(self):
         queryset = Order.objects.all()
-        start_date = parse_datetime(self.request.query_params.get('start_date'))
-        embargo_date = parse_datetime(self.request.query_params.get('embargo_date'))
-        if start_date and embargo_date:
+
+        # parse query string parameters
+        start_date_query = self.request.query_params.get('start_date')
+        embargo_date_query = self.request.query_params.get('embargo_date')
+        
+        # filter queryset within both dates if valid dates are provided together
+        if start_date_query and embargo_date_query:
+            start_date = parse_datetime(start_date_query)
+            embargo_date = parse_datetime(embargo_date_query)
             queryset = queryset.filter(start_date__gte=start_date, embargo_date__lte=embargo_date)
 
         return queryset


### PR DESCRIPTION
### Add start_date and embargo_date filtering to *order-list*

#### Affected APIs:
**Order**

#### Affected Paths:
`GET /order`

#### Usage:
GET requests to /order can include query string parameters `start_date` and `embargo_date` to filter results to only those which fall within both dates respectively.  Accepted values are valid ISO 8601 date strings.

####  Example 
Request
```
GET /order?start_date=2024-10-30&embargo_date=2024-06-29
```

Response Status: **200**
```
{
	"id": 1,
	"inventory": {...},
	"start_date": "2024-10-30",
	"embargo_date": "2024-06-29",
	"tags": {...},
	"is_active": true
}
```