### PR TITLE
post-test-changes/challenge-5

### DIFF
--- a/interview/inventory/fixtures/inventory_views_fixtures.json
+++ b/interview/inventory/fixtures/inventory_views_fixtures.json
@@ -1,0 +1,174 @@
+[
+    {
+      "model": "inventory.inventorylanguage",
+      "pk": 1,
+      "fields": {
+          "created_at": "2024-05-30T19:36:17.594Z",
+          "updated_at": "2024-05-30T19:36:17.594Z",
+          "name": "Abkhaz"
+      }
+  },
+  {
+    "model": "inventory.inventorytype",
+    "pk": 3,
+    "fields": {
+        "created_at": "2024-05-30T19:36:17.713Z",
+        "updated_at": "2024-05-30T19:36:17.713Z",
+        "name": "Version"
+    }
+  },
+  {
+    "model": "inventory.inventorytag",
+    "pk": 1,
+    "fields": {
+        "created_at": "2024-05-30T19:36:17.701Z",
+        "updated_at": "2024-05-30T19:36:17.701Z",
+        "is_active": true,
+        "name": "Action"
+    }
+  },
+  {
+      "model": "inventory.inventory",
+      "pk": 1,
+      "fields": {
+          "created_at": "2024-05-01T19:36:17.716Z",
+          "updated_at": "2024-05-30T19:36:17.716Z",
+          "name": "The Matrix",
+          "type": 3,
+          "language": 1,
+          "metadata": {
+              "year": 1999,
+              "actors": [
+                  "Keanu Reeves",
+                  "Laurence Fishburne",
+                  "Carrie-Anne Moss"
+              ],
+              "imdb_rating": 8.7,
+              "rotten_tomatoes_rating": 87
+          },
+          "tags": [
+              1
+          ]
+      }
+  },
+  {
+      "model": "inventory.inventory",
+      "pk": 5,
+      "fields": {
+          "created_at": "2024-05-5T19:36:17.742Z",
+          "updated_at": "2024-05-30T19:36:17.742Z",
+          "name": "The Lord of the Rings: The Fellowship of the Ring",
+          "type": 3,
+          "language": 1,
+          "metadata": {
+              "year": 2001,
+              "actors": [
+                  "Elijah Wood",
+                  "Ian McKellen",
+                  "Viggo Mortensen"
+              ],
+              "imdb_rating": 8.8,
+              "rotten_toamtoes_rating": 91
+          },
+          "tags": [
+              1
+          ]
+      }
+  },
+  {
+    "model": "inventory.inventory",
+    "pk": 6,
+    "fields": {
+        "created_at": "2024-05-5T19:36:17.742Z",
+        "updated_at": "2024-05-30T19:36:17.742Z",
+        "name": "The Lord of the Rings: The Fellowship of the Ring",
+        "type": 3,
+        "language": 1,
+        "metadata": {
+            "year": 2001,
+            "actors": [
+                "Elijah Wood",
+                "Ian McKellen",
+                "Viggo Mortensen"
+            ],
+            "imdb_rating": 8.8,
+            "rotten_toamtoes_rating": 91
+        },
+        "tags": [
+            1
+        ]
+    }
+},
+{
+    "model": "inventory.inventory",
+    "pk": 7,
+    "fields": {
+        "created_at": "2024-05-5T19:36:17.742Z",
+        "updated_at": "2024-05-30T19:36:17.742Z",
+        "name": "The Lord of the Rings: The Fellowship of the Ring",
+        "type": 3,
+        "language": 1,
+        "metadata": {
+            "year": 2001,
+            "actors": [
+                "Elijah Wood",
+                "Ian McKellen",
+                "Viggo Mortensen"
+            ],
+            "imdb_rating": 8.8,
+            "rotten_toamtoes_rating": 91
+        },
+        "tags": [
+            1
+        ]
+    }
+},
+{
+    "model": "inventory.inventory",
+    "pk": 8,
+    "fields": {
+        "created_at": "2024-05-5T19:36:17.742Z",
+        "updated_at": "2024-05-30T19:36:17.742Z",
+        "name": "The Lord of the Rings: The Fellowship of the Ring",
+        "type": 3,
+        "language": 1,
+        "metadata": {
+            "year": 2001,
+            "actors": [
+                "Elijah Wood",
+                "Ian McKellen",
+                "Viggo Mortensen"
+            ],
+            "imdb_rating": 8.8,
+            "rotten_toamtoes_rating": 91
+        },
+        "tags": [
+            1
+        ]
+    }
+},
+{
+    "model": "inventory.inventory",
+    "pk": 9,
+    "fields": {
+        "created_at": "2024-05-5T19:36:17.742Z",
+        "updated_at": "2024-05-30T19:36:17.742Z",
+        "name": "The Lord of the Rings: The Fellowship of the Ring",
+        "type": 3,
+        "language": 1,
+        "metadata": {
+            "year": 2001,
+            "actors": [
+                "Elijah Wood",
+                "Ian McKellen",
+                "Viggo Mortensen"
+            ],
+            "imdb_rating": 8.8,
+            "rotten_toamtoes_rating": 91
+        },
+        "tags": [
+            1
+        ]
+    }
+}
+  ]

--- a/interview/inventory/tests.py
+++ b/interview/inventory/tests.py
@@ -1,27 +1,11 @@
 from django.test import TestCase
 from django.utils.http import urlencode
-from interview.inventory.models import Inventory
-from datetime import datetime, timedelta
-from django.utils.dateparse import parse_datetime
-from interview.inventory import views
 from rest_framework.response import Response
-from urllib.parse import urlencode
 from interview.inventory.views import INVENTORY_LIST_DEFAULT_PAGE_SIZE, INVENTORY_LIST_MAX_PAGE_SIZE
 
 
 class TestInventoryViews(TestCase):
-    fixtures = ['inventory_views_fixtures.json']
-    inventory_objs = Inventory.objects.all().order_by('created_at')
-    
-    # @classmethod
-    # def setUpClass(cls):
-    #     '''
-    #     Clear all Inventory objects before running tests
-    #     so that only those provided in fixtures are present in database
-    #     '''
-    #     all_inventory = Inventory.objects.all()
-    #     all_inventory.delete()
-    #     super(TestInventoryViews, cls).setUpClass()
+    fixtures = ['inventory_views_fixtures.json']    
 
     def request_with_querystring(self, path, **kwargs) -> Response:
         '''

--- a/interview/inventory/tests.py
+++ b/interview/inventory/tests.py
@@ -1,0 +1,52 @@
+from django.test import TestCase
+from django.utils.http import urlencode
+from interview.inventory.models import Inventory
+from datetime import datetime, timedelta
+from django.utils.dateparse import parse_datetime
+from interview.inventory import views
+from rest_framework.response import Response
+from urllib.parse import urlencode
+from interview.inventory.views import INVENTORY_LIST_DEFAULT_PAGE_SIZE, INVENTORY_LIST_MAX_PAGE_SIZE
+
+
+class TestInventoryViews(TestCase):
+    fixtures = ['inventory_views_fixtures.json']
+    inventory_objs = Inventory.objects.all().order_by('created_at')
+    
+    # @classmethod
+    # def setUpClass(cls):
+    #     '''
+    #     Clear all Inventory objects before running tests
+    #     so that only those provided in fixtures are present in database
+    #     '''
+    #     all_inventory = Inventory.objects.all()
+    #     all_inventory.delete()
+    #     super(TestInventoryViews, cls).setUpClass()
+
+    def request_with_querystring(self, path, **kwargs) -> Response:
+        '''
+        form a querystring from the kwargs and make a request to path
+        '''
+        qs = urlencode(kwargs)
+        path = f"{path}?{qs}"
+        return self.client.get(path)
+    
+    def test_inventory_pagination_exists(self) -> None:
+        '''
+        Test that response has paginated results set with the correct
+        number of items
+        '''
+        res = self.client.get('/inventory/')
+        self.assertEquals(len(res.data['results']), INVENTORY_LIST_DEFAULT_PAGE_SIZE)       
+        [self.assertIn(key, res.data) for key in ['count', 'next', 'previous', 'results']]
+
+    def test_inventory_pagination_limit(self) -> None:
+        '''
+        Test that providing a limit querystring parameter changes the
+        results set size up to the limit maximum
+        '''
+        res = self.request_with_querystring('/inventory/', limit=2)
+        self.assertEquals(len(res.data['results']), 2)
+        res = self.request_with_querystring('/inventory/', limit=INVENTORY_LIST_MAX_PAGE_SIZE + 1)
+        self.assertEquals(len(res.data['results']), INVENTORY_LIST_MAX_PAGE_SIZE)
+


### PR DESCRIPTION
### Add pagination to *inventory-list*

#### Affected APIs:
**Inventory**

#### Affected Paths:
`GET /inventory`

#### Usage:
Requests to inventory-list return paginated data with a page size of 3. `limit` and `offset` querystring parameters can be used to change page size and index.  Results set is moved into key `results` and additional pagination data is provided in the response.

####  Example 
Request
```
GET /inventory?limit=3&offset=5
```

Response Status: **200**
```
{
	"count": 17,
	"next": "http://127.0.0.1:8000/inventory/?limit=3&offset=8",
	"previous": "http://127.0.0.1:8000/inventory/?limit=3&offset=2",
	"results": [
                { <inventory object> },
                { <inventory object> },
                { <inventory object> }
	]
}
```