### PR TITLE
post-test-changes/challenge-6

### DIFF
--- a/interview/order/fixtures/order_views_fixtures.json
+++ b/interview/order/fixtures/order_views_fixtures.json
@@ -1,0 +1,82 @@
+[
+
+
+    {
+        "model": "inventory.inventorylanguage",
+        "pk": 1,
+        "fields": {
+            "created_at": "2024-05-30T19:36:17.594Z",
+            "updated_at": "2024-05-30T19:36:17.594Z",
+            "name": "Abkhaz"
+        }
+    },
+    {
+      "model": "inventory.inventorytype",
+      "pk": 3,
+      "fields": {
+          "created_at": "2024-05-30T19:36:17.713Z",
+          "updated_at": "2024-05-30T19:36:17.713Z",
+          "name": "Version"
+      }
+    },
+    {
+      "model": "inventory.inventorytag",
+      "pk": 1,
+      "fields": {
+          "created_at": "2024-05-30T19:36:17.701Z",
+          "updated_at": "2024-05-30T19:36:17.701Z",
+          "is_active": true,
+          "name": "Action"
+      }
+    },
+    {
+        "model": "order.ordertag",
+        "pk": 1,
+        "fields": {
+            "created_at": "2024-05-30T19:36:17.701Z",
+            "updated_at": "2024-05-30T19:36:17.701Z",
+            "is_active": true,
+            "name": "A Tag"
+        }
+      },
+    
+    {
+        "model": "order.order",
+        "pk": 1,
+        "fields": {
+            "created_at": "2024-05-30T19:36:17.811Z",
+            "updated_at": "2024-05-30T19:36:17.811Z",
+            "is_active": false,
+            "inventory": 1,
+            "start_date": "2024-05-30",
+            "embargo_date": "2024-06-29",
+            "tags": [
+                1
+            ]
+        }
+    },
+    {
+        "model": "inventory.inventory",
+        "pk": 1,
+        "fields": {
+            "created_at": "2024-05-01T19:36:17.716Z",
+            "updated_at": "2024-05-30T19:36:17.716Z",
+            "name": "The Matrix",
+            "type": 3,
+            "language": 1,
+            "metadata": {
+                "year": 1999,
+                "actors": [
+                    "Keanu Reeves",
+                    "Laurence Fishburne",
+                    "Carrie-Anne Moss"
+                ],
+                "imdb_rating": 8.7,
+                "rotten_tomatoes_rating": 87
+            },
+            "tags": [
+                1
+            ]
+        }
+    }
+    ]

--- a/interview/order/tests.py
+++ b/interview/order/tests.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+from interview.order.models import Order
+
+
+class TestOrderViews(TestCase):
+    fixtures = ['order_views_fixtures.json']
+    order_objs = Order.objects.all()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Clear all Order objects before running tests
+        so that only those provided in fixtures are present in database
+        '''
+        all_orders = Order.objects.all()
+        all_orders.delete()
+        super(TestOrderViews, cls).setUpClass()
+
+    def test_get_order_tags(self) -> None:
+        '''
+        Test getting all tags for an order id returns
+        the correct number of tags
+        '''
+        order = self.order_objs.first()
+        response = self.client.get(f'/orders/{order.id}/tags/')
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(len(response.data), len(order.tags.all()))

--- a/interview/order/urls.py
+++ b/interview/order/urls.py
@@ -1,10 +1,11 @@
 
 from django.urls import path
-from interview.order.views import OrderListCreateView, OrderTagListCreateView
+from interview.order.views import OrderListCreateView, OrderTagListCreateView, OrderTagsRetrieveView
 
 
 urlpatterns = [
     path('tags/', OrderTagListCreateView.as_view(), name='order-detail'),
+    path('<int:pk>/tags/', OrderTagsRetrieveView.as_view(), name="order-tags"),
     path('', OrderListCreateView.as_view(), name='order-list'),
 
 ]

--- a/interview/order/views.py
+++ b/interview/order/views.py
@@ -1,15 +1,29 @@
 from django.shortcuts import render
 from rest_framework import generics
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 from interview.order.models import Order, OrderTag
 from interview.order.serializers import OrderSerializer, OrderTagSerializer
 
-# Create your views here.
+
 class OrderListCreateView(generics.ListCreateAPIView):
     queryset = Order.objects.all()
     serializer_class = OrderSerializer
-    
+
 
 class OrderTagListCreateView(generics.ListCreateAPIView):
     queryset = OrderTag.objects.all()
     serializer_class = OrderTagSerializer
+
+
+class OrderTagsRetrieveView(generics.RetrieveAPIView):
+
+    def get(self, request, **kwargs):
+        '''
+        Get all tags for Order
+        '''
+        tags = Order.objects.get(id=kwargs['pk']).tags.all()
+        serializer = OrderTagSerializer(tags, many=True)
+
+        return Response(serializer.data, status=200)


### PR DESCRIPTION
### Add *order-tags* to get all tags of an order

#### Affected APIs:
**Order**

#### New Endpoint:

```
GET /order/<int:order_id>/tags
``` 
#### Usage:
Requests can be made for the tags resource of an individual order by providing the Order id in the path along with `tags/`


####  Example 
Request
```
GET /orders/2/tags/
```
Response Status: **200**
```
[
	{
		"id": 8,
		"name": "Chicago",
		"is_active": true
	},
	{
		"id": 12,
		"name": "Delivered",
		"is_active": true
	},
	{
		"id": 17,
		"name": "Dubbing",
		"is_active": true
	}
]
```